### PR TITLE
Relative path to module files

### DIFF
--- a/AzFilesHybrid/CopyToPSPath.ps1
+++ b/AzFilesHybrid/CopyToPSPath.ps1
@@ -3,11 +3,11 @@ if (!(Test-Path -Path $psModPath)) {
     New-Item -Path $psModPath -ItemType Directory | Out-Null
 }
 
-$psdFile = Import-PowerShellDataFile -Path .\AzFilesHybrid.psd1
+$psdFile = Import-PowerShellDataFile -Path $PSScriptRoot\AzFilesHybrid.psd1
 $desiredModulePath = "$psModPath\AzFilesHybrid\$($psdFile.ModuleVersion)\"
 if (!(Test-Path -Path $desiredModulePath)) {
     New-Item -Path $desiredModulePath -ItemType Directory | Out-Null
 }
 
-Copy-Item -Path ".\AzFilesHybrid.psd1" -Destination $desiredModulePath
-Copy-Item -Path ".\AzFilesHybrid.psm1" -Destination $desiredModulePath
+Copy-Item -Path "$PSScriptRoot\AzFilesHybrid.psd1" -Destination $desiredModulePath
+Copy-Item -Path "$PSScriptRoot\AzFilesHybrid.psm1" -Destination $desiredModulePath


### PR DESCRIPTION
Use $PSScriptRoot as an relative path to the module files if not in current directory.