### PR TITLE
Added RoboCopy capabilities

### DIFF
--- a/ScanUnsupportedChars/ScanUnsupportedChars.ps1
+++ b/ScanUnsupportedChars/ScanUnsupportedChars.ps1
@@ -83,8 +83,7 @@
  
  .EXAMPLE
       .\ScanUnsupportedChars.ps1  -SharePath  \\server\SyncShare  -DestinationPath "\\some\server" -RoboCopyOptions '/SEC'
-      This would scan unsupported file names for the provided remote SyncShare and puts the output in the
-      CSV formatted files in the output directory.
+      This would scan unsupported file names for the provided remote SyncShare and puts the output in the Destination Path
 
  .NOTES
      Script Limitations:

--- a/ScanUnsupportedChars/ScanUnsupportedChars.ps1
+++ b/ScanUnsupportedChars/ScanUnsupportedChars.ps1
@@ -10,8 +10,8 @@
    Scan provided share to get the file names not suported by AFS.
    It can also fix those files by replacing the unsupported char with the provided string in the files names.
 
-   Version 4.6
-   Last Modified Date: Nov 16, 2020
+   Version 4.7
+   Last Modified Date: Nov 27, 2020
 
     Example usage:
  

--- a/ScanUnsupportedChars/ScanUnsupportedChars.ps1
+++ b/ScanUnsupportedChars/ScanUnsupportedChars.ps1
@@ -762,7 +762,7 @@ if ($FilesWithInvalidCharsFixedName.Count -gt 0)
 
         Write-Host "***************************Items failed to rename table end*****************************" -ForegroundColor Yellow
     }
-    elseif($PSBoundParameters.ContainsKey('DestinationPath'))
+    elseif($PSBoundParameters.ContainsKey('DestinationPath') -and !($PSBoundParameters.ContainsKey('RenameItems')))
     {
         Write-Host "========================== File COPY/MOVE start ==========================================" -ForegroundColor Yellow
         Write-Host "Ensure UTF-8 Codepage and Encoding"

--- a/ScanUnsupportedChars/ScanUnsupportedChars.ps1
+++ b/ScanUnsupportedChars/ScanUnsupportedChars.ps1
@@ -91,7 +91,6 @@
         the fixed file name would be empty string, hence cannot be renamed into.
      2. If after replacing the unsupported chars, two or more files gets the same fixed name, the script would not
         be able to rename them due to name collision.
-     3. If Folders have unsupported chars in the name, Azure FileSync will not pick them up, but folder names are not yet scanned
 #>
 
 [CmdletBinding()]
@@ -786,7 +785,6 @@ if ($FilesWithInvalidCharsFixedName.Count -gt 0)
                 $root = [System.IO.Path]::GetPathRoot($path);
                 $relative_path = $path.Remove(0, $root.Length);
                 $file_name = [System.IO.Path]::GetFileName($path)
-                $source = [System.IO.Path]::GetDirectoryName($path + '\')
 
                 if($file.Type -eq 'FOLDER'){
                     Write-Host "START - UNSUPORTED FOLDER: " $file.OriginalFilePath

--- a/ScanUnsupportedChars/ScanUnsupportedChars.ps1
+++ b/ScanUnsupportedChars/ScanUnsupportedChars.ps1
@@ -19,15 +19,15 @@
 
     Set-ExecutionPolicy Unrestricted
        1. Just to see all files with unsupported chars on console window with unsupported char replaced by 'empty string'
-       .\ScanUnsupportedChars.ps1Â  -SharePathÂ  <LocalShareRootPath>
+       .\ScanUnsupportedChars.ps1  -SharePath  <LocalShareRootPath>
        2. Just to see all files with unsupported chars on console window with unsupported char replaced by 'YourOwnString'
-       .\ScanUnsupportedChars.ps1Â  -SharePathÂ  <LocalShareRootPath> -ReplacementString "YourOwnString"
+       .\ScanUnsupportedChars.ps1  -SharePath  <LocalShareRootPath> -ReplacementString "YourOwnString"
        3. If you want to replace the unsupported char with your own string do
-       .\ScanUnsupportedChars.ps1Â  -SharePathÂ  <LocalShareRootPath> -RenameItem -ReplacementString "YourOwnString"
+       .\ScanUnsupportedChars.ps1  -SharePath  <LocalShareRootPath> -RenameItem -ReplacementString "YourOwnString"
        4. If you want to remove the unsupported char from file paths do
-       .\ScanUnsupportedChars.ps1Â  -SharePathÂ  <LocalShareRootPath> -RenameItem
+       .\ScanUnsupportedChars.ps1  -SharePath  <LocalShareRootPath> -RenameItem
        5. If you want to dump the script output to CSV files
-       .\ScanUnsupportedChars.ps1Â  -SharePathÂ  <LocalShareRootPath> -CsvPath <DirectoryPathForCSVFiles>
+       .\ScanUnsupportedChars.ps1  -SharePath  <LocalShareRootPath> -CsvPath <DirectoryPathForCSVFiles>
      Set-ExecutionPolicy AllSigned
 
  .PARAMETER SharePath
@@ -49,40 +49,40 @@
      Through this Arguments it can be controlled if Files should be moved / copied and/or overriden
      
  .EXAMPLE
-     .\ScanUnsupportedChars.ps1Â  -SharePathÂ  E:\SyncShare
+     .\ScanUnsupportedChars.ps1  -SharePath  E:\SyncShare
       This would scan the provided SyncShare for the unsupported file names.
 
  .EXAMPLE
-     .\ScanUnsupportedChars.ps1Â  -SharePathÂ  E:\SyncShare -RenameItem
+     .\ScanUnsupportedChars.ps1  -SharePath  E:\SyncShare -RenameItem
       This would scan and rename the unsupported file names in the provided sync share.
       This would replace the unsupported char with empty string.
 
  .EXAMPLE
-      .\ScanUnsupportedChars.ps1Â  -SharePathÂ  E:\SyncShare -RenameItem -ReplacementString "-"
+      .\ScanUnsupportedChars.ps1  -SharePath  E:\SyncShare -RenameItem -ReplacementString "-"
       This would scan and rename the unsupported file names in the provided sync share.
       This would replace the unsupported char with "-".
 
  .EXAMPLE
-      .\ScanUnsupportedChars.ps1Â  -SharePathÂ  \\server\SyncShare 
+      .\ScanUnsupportedChars.ps1  -SharePath  \\server\SyncShare 
         This would scan the provided remote SyncShare for the unsupported file names.
 
  .EXAMPLE
-      .\ScanUnsupportedChars.ps1Â  -SharePathÂ  \\server\SyncShare  -RenameItem
+      .\ScanUnsupportedChars.ps1  -SharePath  \\server\SyncShare  -RenameItem
       This would scan and rename the unsupported file names for the provided remote SyncShare.
       This would replace the unsupported char with empty string.
 
  .EXAMPLE
-      .\ScanUnsupportedChars.ps1Â  -SharePathÂ  \\server\SyncShare  -RenameItem -ReplacementString "-"
+      .\ScanUnsupportedChars.ps1  -SharePath  \\server\SyncShare  -RenameItem -ReplacementString "-"
       This would scan and rename the unsupported file names for the provided remote SyncShare.
       This would replace the unsupported char with "-".
 
  .EXAMPLE
-      .\ScanUnsupportedChars.ps1Â  -SharePathÂ  \\server\SyncShare  -CsvPath "C:\temp"
+      .\ScanUnsupportedChars.ps1  -SharePath  \\server\SyncShare  -CsvPath "C:\temp"
       This would scan unsupported file names for the provided remote SyncShare and puts the output in the
       CSV formatted files in the output directory.
  
  .EXAMPLE
-      .\ScanUnsupportedChars.ps1Â  -SharePathÂ  \\server\SyncShare  -DestinationPath "\\some\server" -RoboCopyOptions '/SEC'
+      .\ScanUnsupportedChars.ps1  -SharePath  \\server\SyncShare  -DestinationPath "\\some\server" -RoboCopyOptions '/SEC'
       This would scan unsupported file names for the provided remote SyncShare and puts the output in the Destination Path
 
  .NOTES

--- a/ScanUnsupportedChars/ScanUnsupportedChars.ps1
+++ b/ScanUnsupportedChars/ScanUnsupportedChars.ps1
@@ -787,7 +787,6 @@ if ($FilesWithInvalidCharsFixedName.Count -gt 0)
                 $file_name = [System.IO.Path]::GetFileName($path)
 
                 if($file.Type -eq 'FOLDER'){
-                    Write-Host "START - UNSUPORTED FOLDER: " $file.OriginalFilePath
                     $source = [System.IO.Path]::GetDirectoryName($path + '\')
                     $destination = [System.IO.Path]::Combine($DestinationPath, [System.IO.Path]::GetDirectoryName($relative_path + '\'));
                     
@@ -800,7 +799,6 @@ if ($FilesWithInvalidCharsFixedName.Count -gt 0)
                     $source = [System.IO.Path]::GetDirectoryName($path)
                     $destination = [System.IO.Path]::Combine($DestinationPath, [System.IO.Path]::GetDirectoryName($relative_path));
                 
-                    Write-Host "START - UNSUPORTED FILE: " $file.OriginalFilePath
                     $allArgs = @('"' + $source + '"', '"' + $destination + '"', '"'+ $file_name +'"', $RoboCopyOptions)
                     Start-Process Robocopy.exe -ArgumentList $allArgs -NoNewWindow -Wait -PassThru
                     Write-Host 'File'$file_name' copied from '$SharePath' to '$destination -ForegroundColor Green

--- a/ScanUnsupportedChars/readme.md
+++ b/ScanUnsupportedChars/readme.md
@@ -33,4 +33,18 @@ Example to rename the files and replace the invalid character with a hyphen**
 c:\script\ScanUnsupportedChars.ps1 -SharePath \\testshare.file.core.windows.net\filesharename -RenameItem -ReplacementString "-" | Out-File -FilePath c:\script\output.txt
 ```
 
+Example to **copy** all files and directories with invalid characters.
+Folders containing invalid chars, will not be synced so all contents are copied over as well.
+```powershell
+c:\script\ScanUnsupportedChars.ps1 -SharePath \\testshare.file.core.windows.net\filesharename -DestinationPath '\\some\share'
+```
+
+Example to **move** all files and directories with invalid characters.
+Folders containing invalid chars, will not be synced so all contents are moved over as well.
+```powershell
+c:\script\ScanUnsupportedChars.ps1 -SharePath \\testshare.file.core.windows.net\filesharename -DestinationPath '\\some\share' -RoboCopyOptions '/MOV'
+```
+
+The -RoboCopyOptions parameter allows for any valid RoboCopy Switch to be set. For Directories the /E switch will be automatically set. All options provided through this, will be attached to the individual file copy and the directory copy process as well.
+
 **Note**: The -SharePath can be a local path (if the share is mounted on the server or using Azure File Sync) or a network path. See additional examples provided in the script.


### PR DESCRIPTION
As discussed via Mail, this gives options to the script to copy over files via robocopy if file names are not supported.

This allows alternative backup drops for such files. The relative location SharePath as origin will be preserved in the destination path (new parameter). Because of the Unicode support, the options of passing parameters had been a bit restrictive.

If you know/have a better solution for the workaround, please feel free to reject with some hints. Start-Process does not allow redirection to $null or append redirected output.