### PR TITLE
Added PS Core support to Set-StorageAccountDomainProperties

### DIFF
--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -3759,11 +3759,16 @@ function Set-StorageAccountDomainProperties {
             -ADObjectName $ADObjectName `
             -Domain $Domain `
             -ErrorAction Stop
-        $azureStorageSid = $azureStorageIdentity.SID.Value
 
+        if ($PSVersionTable.PSEdition -eq 'Core') {
+            $domainSid = $domainInformation.DomainSID
+            $azureStorageSid = $azureStorageIdentity.SID
+        } else {
+            $domainSid = $domainInformation.DomainSID.Value
+            $azureStorageSid = $azureStorageIdentity.SID.Value
+        }
         $domainGuid = $domainInformation.ObjectGUID.ToString()
         $domainName = $domainInformation.DnsRoot
-        $domainSid = $domainInformation.DomainSID.Value
         $forestName = $domainInformation.Forest
         $netBiosDomainName = $domainInformation.DnsRoot
 


### PR DESCRIPTION
The goal of this PR is to bring PS Core support to avoid issues for folks who work with PowerShell 7+. 

### Issues
This PR addresses the following issues
#63 
#57 

I'm open to any comments, suggestions.
Thank you!