### PR TITLE
Use -Current LocalComputer for Get-ADDomain

### DIFF
--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -2665,7 +2665,7 @@ function Get-AzStorageAccountADObject {
 
         if ($PSCmdlet.ParameterSetName -eq "ADObjectName") {
             if ([System.String]::IsNullOrEmpty($Domain)) {
-                $domainInfo = Get-Domain
+                $domainInfo = Get-ADDomain -Current LocalComputer
                 $Domain = $domainInfo.DnsRoot
             }
         }
@@ -3749,7 +3749,7 @@ function Set-StorageAccountDomainProperties {
         Write-Verbose "Set-StorageAccountDomainProperties: Enabling the feature on the storage account and providing the required properties to the storage service"
 
         if ([System.String]::IsNullOrEmpty($Domain)) {
-            $domainInformation = Get-ADDomain
+            $domainInformation = Get-ADDomain -Current LocalComputer
             $Domain = $domainInformation.DnsRoot
         } else {
             $domainInformation = Get-ADDomain -Server $Domain


### PR DESCRIPTION
In order to get this module to work, I needed to make two edits. In the first, I had to completely replace the referenced function, `Get-Domain`, because it didn't exist, and in the second case, I had to add `-Current LocalComputer` in order force the command to use the local domain context.

Craig