### PR TITLE
Bugfix/fix null reference exceptions

### DIFF
--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -3388,7 +3388,7 @@ function Debug-KerberosTicketEncryption
         if(
             $null -eq $kerberosTicketEncryptionClient -or `
             0 -eq $kerberosTicketEncryptionClient.Count -or `
-            'None' -eq $kerberosTicketEncryptionClient.Value.ToString()
+            ($kerberosTicketEncryptionClient.Value -and 'None' -eq $kerberosTicketEncryptionClient.Value.ToString())
             )
         {
             # Now try to look for the supported kerberos ticket encryption using klist
@@ -3805,7 +3805,7 @@ function Debug-AzStorageAccountAuth {
                     $checks["CheckChannelEncryption"].Result = "Skipped"
                 }
 
-                if(!(Get-SmbServerConfiguration).PSobject.Properties.Name -contains "EncryptionCiphers")
+                if(!((Get-SmbServerConfiguration).PSobject.Properties.Name -contains "EncryptionCiphers"))
                 {
                     Write-Verbose -Message "Your operating system does not support the property 'EncryptionCiphers' of the cmdlet 'Get-SmbServerConfiguration'. Please refer to 'https://docs.microsoft.com/en-us/powershell/module/smbshare/set-smbserverconfiguration?view=windowsserver2022-ps'"
                     $checks["CheckChannelEncryption"].Result = "Skipped"
@@ -4282,11 +4282,11 @@ function Set-StorageAccountDomainProperties {
             -SPNValue $spnValue `
             -Domain $Domain `
             -ErrorAction Stop
-        $azureStorageSid = $azureStorageIdentity.SID.Value
+        $azureStorageSid = $azureStorageIdentity.SID
         $samAccountName = $azureStorageIdentity.SamAccountName.TrimEnd("$")
         $domainGuid = $domainInformation.ObjectGUID.ToString()
         $domainName = $domainInformation.DnsRoot
-        $domainSid = $domainInformation.DomainSID.Value
+        $domainSid = $domainInformation.DomainSID
         $forestName = $domainInformation.Forest
         $netBiosDomainName = $domainInformation.DnsRoot
         $accountType = ""
@@ -4615,7 +4615,7 @@ function Update-AzStorageAccountADObjectPassword {
             # if ($Force.ToBool()) {
                 Write-Verbose -Message ("Attempt reset on " + $adObj.SamAccountName + " to $RotateToKerbKey")
                 Set-ADAccountPassword `
-                    -Identity $adObj `
+                    -Identity $adObj.DistinguishedName `
                     -Reset `
                     -NewPassword $newPassword `
                     -Server $domain `

--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -3981,10 +3981,10 @@ function Debug-AzStorageAccountAuth {
 
                 $sidNames = @{}
                 $user = Get-OnPremAdUser -Identity $UserName -Domain $Domain -ErrorAction Stop
-                $sidNames[$user.SID.Value] = $user.DistinguishedName
+                $sidNames[$user.SID] = $user.DistinguishedName
 
                 $groups = Get-OnPremAdUserGroups -Identity $user.SID -Domain $Domain -ErrorAction Stop
-                $groups | ForEach-Object { $sidNames[$_.SID.Value] = $_.DistinguishedName }
+                $groups | ForEach-Object { $sidNames[$_.SID] = $_.DistinguishedName }
 
                 # The user needs following role assignments to have the share-level access.
                 # Currently only three roles are defined, but new ones may be added in future,


### PR DESCRIPTION
This is what I needed to do to get the script to run reliably on Server 2019, Powershell 7.3.1

In Debug-KerberosTicketEncryption - if $kerberosTicketEncryptionClient is an array with 1 element, the condition then goes on to try to read the .Value property, which is $null. Then .ToString() on this gives a null reference. I added a check to cope with this.

The check for EncryptionCiphers 
```(Get-SmbServerConfiguration).PSobject.Properties.Name -contains "EncryptionCiphers"```
was missing an outer set of brackets which stopped it from detecting that this property was missing on down-level servers.

There were a number of calls to the .Value property of the SID - this is a string already so we get $null rather than the desired value - causing null reference exceptions.

The Set-ADAccountPassword cmdlet takes a string DN in the -Identity property, not an object.



