### PR TITLE
Do verbose logging only when instructed.

### DIFF
--- a/SMBDiagnostics/smbclientlogs.sh
+++ b/SMBDiagnostics/smbclientlogs.sh
@@ -16,7 +16,7 @@ main() {
   then
     stop 0<&- > "${STDLOG_FILE}" 2>&1
   else
-    echo "Usage: ./smbclientlogs.sh <start | stop> <CaptureNetwork>"
+    echo "Usage: ./smbclientlogs.sh <start | stop> <CaptureNetwork> <VerboseLogs>"
     exit 1
   fi
 
@@ -25,7 +25,7 @@ main() {
 
 start() {
   init
-  start_trace
+  start_trace $@
   dump_os_information
   echo "======= Dumping CIFS Debug Stats at start =======" > cifs_diag.txt
   dump_debug_stats
@@ -77,9 +77,11 @@ check_utils() {
 }
 
 start_trace() {
-  echo 'module cifs +p' > /sys/kernel/debug/dynamic_debug/control
-  echo 'file fs/cifs/* +p' > /sys/kernel/debug/dynamic_debug/control
-  echo 7 > /proc/fs/cifs/cifsFYI
+  if [[ "$*" =~ "VerboseLogs" ]]; then
+    echo 'module cifs +p' > /sys/kernel/debug/dynamic_debug/control
+    echo 'file fs/cifs/* +p' > /sys/kernel/debug/dynamic_debug/control
+    echo 7 > /proc/fs/cifs/cifsFYI
+  fi
   trace-cmd start -e cifs
 }
 

--- a/SMBDiagnostics/smbclientlogs.sh
+++ b/SMBDiagnostics/smbclientlogs.sh
@@ -6,7 +6,7 @@ CIFS_PORT=445
 TRACE_CIFSBPF_ABS_PATH="$(cd "$(dirname "trace-cifsbpf")" && pwd)/$(basename "trace-cifsbpf")"
 PYTHON_PROG='python'
 STDLOG_FILE='/dev/null'
-
+CIFS_FYI_ENABLED=0
 
 main() {
   if [[ "$*" =~ "start" ]]
@@ -81,6 +81,7 @@ start_trace() {
     echo 'module cifs +p' > /sys/kernel/debug/dynamic_debug/control
     echo 'file fs/cifs/* +p' > /sys/kernel/debug/dynamic_debug/control
     echo 7 > /proc/fs/cifs/cifsFYI
+    CIFS_FYI_ENABLED=1
   fi
   trace-cmd start -e cifs
 }
@@ -140,7 +141,9 @@ stop_trace() {
   trace-cmd report > "${DIRNAME}/cifs_trace"
   trace-cmd stop
   trace-cmd reset
-  echo 0 > /proc/fs/cifs/cifsFYI
+  if [ $CIFS_FYI_ENABLED -ne 0 ]; then
+    echo 0 > /proc/fs/cifs/cifsFYI
+  fi
   rm -rf trace.dat*
 }
 


### PR DESCRIPTION
Right now we enable cifsFYI logs unconditionally when capturing diagnostics. But this makes changes to debugfs, which will not be possible with kernel lockdown enabled, and that is the default with trusted VMs which are becoming more common.

Additionally, we do not use verbose logs much for our debugging. We have grown to use trace-cmd more.

This change disables verbose logging by default.

No need to document this. It will complicate the instructions for the customers. Instruct customers specially when verbose logs are needed.