### PR TITLE
Reg Key check for AD DS

### DIFF
--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -4251,7 +4251,7 @@ function Debug-AzStorageAccountAuth {
                     $checks["CheckAadKerberosRegistryKeyIsOff"].Issue = "CloudKerberosTicketRetrievalEnabled registry key is enabled. Disable it to retrieve Kerberos tickets from AD DS."
 
                     Write-Error "CheckAadKerberosRegistryKeyIsOff - FAILED"
-                    Write-Error "Disable the Reg key to retrieve Kerberos tickets follow-> [https://learn.microsoft.com/en-us/azure/storage/files/storage-files-identity-auth-hybrid-identities-enable?tabs=azure-portal#undo-the-client-configuration-to-retrieve-kerberos-tickets]"
+                    Write-Error "For AD DS authentication, you must disable the registry key for retrieving Kerberos tickets from AAD. See https://learn.microsoft.com/en-us/azure/storage/files/storage-files-identity-auth-hybrid-identities-enable?tabs=azure-portal#undo-the-client-configuration-to-retrieve-kerberos-tickets"
                 }
                 
             } catch {

--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -3740,7 +3740,8 @@ function Debug-AzStorageAccountAuth {
                 else 
                 {
                     $checks["CheckonRegKey"].Result = "Failed"
-                    $checks["CheckonRegKey"].Issue = "Reg key is enabled. Disable the Reg key to retrieve Kerberos tickets."
+                    $checks["CheckonRegKey"].Issue = "AAD Kerberos Cloud Ticket Retrieval is enabled. Disable the registry key for this, and reboot the machine."
+
                     Write-Error "CheckonRegKey - FAILED"
                     Write-Error "Disable the Reg key to retrieve Kerberos tickets follow-> [https://learn.microsoft.com/en-us/azure/storage/files/storage-files-identity-auth-hybrid-identities-enable?tabs=azure-portal#undo-the-client-configuration-to-retrieve-kerberos-tickets]"
                 }

--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -4248,7 +4248,8 @@ function Debug-AzStorageAccountAuth {
                 else 
                 {
                     $checks["CheckAadKerberosRegistryKeyIsOff"].Result = "Failed"
-                    $checks["CheckAadKerberosRegistryKeyIsOff"].Issue = "Reg key is enabled. Disable the Reg key to retrieve Kerberos tickets."
+                    $checks["CheckAadKerberosRegistryKeyIsOff"].Issue = "CloudKerberosTicketRetrievalEnabled registry key is enabled. Disable it to retrieve Kerberos tickets from AD DS."
+
                     Write-Error "CheckAadKerberosRegistryKeyIsOff - FAILED"
                     Write-Error "Disable the Reg key to retrieve Kerberos tickets follow-> [https://learn.microsoft.com/en-us/azure/storage/files/storage-files-identity-auth-hybrid-identities-enable?tabs=azure-portal#undo-the-client-configuration-to-retrieve-kerberos-tickets]"
                 }


### PR DESCRIPTION
Added a Reg Key check for ADDS. If the Reg key is enabled for AD DS there is an issue in retrieving the Kerberos tickets.