### PR TITLE
Fix regression in nfs stop_trace function, Seems like this code was a…

### DIFF
--- a/NfsDiagnostics/nfsclientlogs.sh
+++ b/NfsDiagnostics/nfsclientlogs.sh
@@ -95,7 +95,23 @@ trace_nfsbpf() {
 }
 
 stop() {
-  dmesg -T  rm -rf trace.dat*
+  dmesg -T > "${DIRNAME}/nfs_dmesg"
+  stop_trace
+  stop_capture_network
+
+  zip -r "$(basename ${DIRNAME}).zip" "${DIRNAME}"
+  return 0;
+}
+
+stop_trace() {
+  trace-cmd extract
+  sleep 1
+  trace-cmd report > "${DIRNAME}/nfs_trace"
+  trace-cmd stop
+  trace-cmd reset
+  rpcdebug -m rpc -c all
+  rpcdebug -m nfs -c all
+  rm -rf trace.dat*
 }
 
 stop_capture_network() {


### PR DESCRIPTION
Fix regression in nfs stop_trace function, looks like this code was accidentally removed. 
This caused nfs diagnostics script to silently fail without capturing any debug information.

The regression was introduced by commit 0bd93beca56acb5af339aa08521ac59f62b9e157