### PR TITLE
Add an utils check for the ss command

### DIFF
--- a/SMBDiagnostics/README
+++ b/SMBDiagnostics/README
@@ -3,7 +3,7 @@ Steps to collect the logs:
 Copy smbclientlogs.sh (Shell script) and trace-cifsbpf (eBPF script) to linux machine where we need to collect logs.
 
 Dependencies:
-Install packages trace-cmd and zip.
+Install packages trace-cmd, zip and ss.
 If using CaptureNetwork option (see below), install tcpdump.
 If using OnAnomaly mode (see below), install bpfcc-tools.
 

--- a/SMBDiagnostics/smbclientlogs.sh
+++ b/SMBDiagnostics/smbclientlogs.sh
@@ -86,6 +86,12 @@ check_utils() {
     exit 1
   fi
 
+  which ss > /dev/null
+  if [ $? == 1 ]; then
+    echo "ss is not installed, please install ss to continue"
+    exit 1
+  fi
+
   which python > /dev/null
   if [ $? == 1 ]; then
     which python3 > /dev/null


### PR DESCRIPTION
The script now relies on the output of the ss command. However, in the initial check for utilities, this tool is not checked. 

This change checks for the utility. If not present, it errors out.