### PR TITLE
Add parallelism option to RestSetAcls

### DIFF
--- a/RestSetAcls/RestSetAcls.psm1
+++ b/RestSetAcls/RestSetAcls.psm1
@@ -258,7 +258,7 @@ function Set-AzureFilesAclRecursive {
         [string]$SddlPermission,
 
         [Parameter(Mandatory=$false)]
-        [switch]$Parallel = $false,
+        [bool]$Parallel = $true,
 
         [Parameter(Mandatory=$false)]
         [int]$ThrottleLimit = 10


### PR DESCRIPTION
Adds a `-Parallel` option, which lets the user opt in to processing the files in parallel. In my tests, with parallelism level 10, this represents somewhere between a 7x and 10x improvement.

Also adds a `-ThrottleLimit` option, which defaults to 10, to control the parallelism level. This might be a useful setting for users to extract the maximal amount of performance for their given situation (network speeds, number of cores, etc).
