### PR TITLE
Minor fixes to RBAC check

### DIFF
--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -3755,11 +3755,9 @@ function Debug-AzStorageAccountAuth {
 
     process
     {
-        $VerifyAD = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -StorageAccountName $StorageAccountName -ErrorAction Stop
-        $directoryServiceOptions = $VerifyAD.AzureFilesIdentityBasedAuth.DirectoryServiceOptions 
-        
-        # Dispatch to the right set of checks, depending on directoryServiceOptions
-        $directoryServiceOptions = $storageAccount.AzureFilesIdentityBasedAuth.DirectoryServiceOptions
+        $storageAccount = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -StorageAccountName $StorageAccountName -ErrorAction Stop
+        $directoryServiceOptions = $storageAccount.AzureFilesIdentityBasedAuth.DirectoryServiceOptions 
+
         if ($directoryServiceOptions -eq "AD")
         {
             Write-Host "Storage account is configured for AD DS auth."

--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -3755,15 +3755,8 @@ function Debug-AzStorageAccountAuth {
 
     process
     {
-        # Check prerequisite: you must be connected to Azure before running this cmdlet.
-        $context = Get-AzContext
-        if ($null -eq $context)
-        {
-            Write-Error "Please login to Azure using Connect-AzAccount before running this cmdlet." -ErrorAction Stop
-        }
-        
-        # Check that resource group, storage account and (optionally) file share exist
-        $storageAccount = Validate-StorageAccount -ResourceGroupName $ResourceGroupName -StorageAccountName $StorageAccountName
+        $VerifyAD = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -StorageAccountName $StorageAccountName -ErrorAction Stop
+        $directoryServiceOptions = $VerifyAD.AzureFilesIdentityBasedAuth.DirectoryServiceOptions 
         
         # Dispatch to the right set of checks, depending on directoryServiceOptions
         $directoryServiceOptions = $storageAccount.AzureFilesIdentityBasedAuth.DirectoryServiceOptions

--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -4364,7 +4364,6 @@ function Debug-RBACCheck {
                         if ($assignment.ObjectId -eq $user.Id) 
                         {
                             $assignedRoles.Add($roleName, "user '$UserPrincipalName'")
-                            break
                         }
                     }
                     elseif ($assignment.ObjectType -eq "Group") 
@@ -4373,7 +4372,6 @@ function Debug-RBACCheck {
                         {
                             $groupDisplayName = $hybridGroupIdToName[$assignment.ObjectId]
                             $assignedRoles.Add($roleName, "group '$groupDisplayName'")
-                            break
                         }
                     }
                 }

--- a/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid.psm1
@@ -4363,7 +4363,7 @@ function Debug-RBACCheck {
                     {
                         if ($assignment.ObjectId -eq $user.Id) 
                         {
-                            $assignedRoles.Add($roleName, $UserPrincipalName)
+                            $assignedRoles.Add($roleName, "user '$UserPrincipalName'")
                             break
                         }
                     }
@@ -4381,22 +4381,23 @@ function Debug-RBACCheck {
 
             if ($assignedRoles.Count -eq 0) {
                 $message = "User '$UserPrincipalName' is not assigned any SMB share-level permission to" `
-                        + " `nstorage account '$StorageAccountName' in resource group '$ResourceGroupName'." `
-                        + " `nPlease configure proper share-level permission following the guidance at" `
-                        + " `n'$($PSStyle.Foreground.BrightCyan)https://docs.microsoft.com/en-us/azure/storage/files/storage-files-identity-ad-ds-assign-permissions$($PSStyle.Reset)'"
-                    Write-Error -Message $message -ErrorAction Stop
+                        + " `n`tstorage account '$StorageAccountName' in resource group '$ResourceGroupName'." `
+                        + " `n`tPlease configure proper share-level permission following the guidance at" `
+                        + " `n`t'$($PSStyle.Foreground.BrightCyan)https://docs.microsoft.com/en-us/azure/storage/files/storage-files-identity-ad-ds-assign-permissions$($PSStyle.Reset)'"
+                
+                $checkResult.Result = "Failed"
+                Write-TestingFailed $message
             }
             else 
             { 
                 $checkResult.Result = "Passed"
-                Write-Host "You have access to the shares, via the following roles:"
                 foreach ($item in $assignedRoles.GetEnumerator())
                 {
                     $role = $item.Name
                     $identity = $item.Value
-                    Write-Host "  - '$role' via $identity"
+                    Write-Host "`t'$role' granted via $identity"
                 }
-                Write-Host
+                Write-TestingPassed
             }
         } 
         catch


### PR DESCRIPTION
- Fix issues with RBAC detection
- Fix bug where MgGraph and Az aren't connected to the same tenant ID when running the command
- Improve RBAC success case messages 
- Fix issue in RBAC check where a stack trace is printed if no username is passed. Print a nicer error message instead.
- Change `UserPrincipalName` param to `UserName`. That way, if you forget to provide it in either `Debug-AzStorageAccountEntraKerbAuth` or `Debug-AzStorageAccountAuth`, the fix is the same. The fact that the UserName is a UserPrincipalName is clarified in the help message
- Fix some spacing issues
- Fix some help messages
- Fix detection of null objectid