### PR TITLE
Fix RestSetAcls compatibility with PowerShell 5

### DIFF
--- a/.github/workflows/RestSetAcls.yml
+++ b/.github/workflows/RestSetAcls.yml
@@ -22,6 +22,23 @@ jobs:
         uses: actions/checkout@v4
       - name: Run all Pester tests
         run: |
+          $PSVersionTable
+          .\init.ps1
+          Test
+
+  pester-test-powershell-5:
+    name: Pester test on PowerShell 5.1
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: .\RestSetAcls
+        shell: powershell
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Run all Pester tests
+        run: |
+          $PSVersionTable
           .\init.ps1
           Test
 

--- a/.github/workflows/RestSetAcls.yml
+++ b/.github/workflows/RestSetAcls.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pester-test:
-    name: Pester test
+    name: Pester test on PowerShell 7
     runs-on: windows-latest
     defaults:
       run:
@@ -20,9 +20,10 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Print PowerShell version
+        run: $PSVersionTable
       - name: Run all Pester tests
         run: |
-          $PSVersionTable
           .\init.ps1
           Test
 
@@ -36,14 +37,15 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Print PowerShell version
+        run: $PSVersionTable
       - name: Run all Pester tests
         run: |
-          $PSVersionTable
           .\init.ps1
           Test
 
   test-format:
-    name: Test PowerShell formatting
+    name: Check PowerShell formatting
     runs-on: windows-latest
     defaults:
       run:

--- a/.github/workflows/RestSetAcls.yml
+++ b/.github/workflows/RestSetAcls.yml
@@ -74,7 +74,7 @@ jobs:
           Test-Manifest
 
   lint-with-PSScriptAnalyzer:
-    name: Install and run PSScriptAnalyzer
+    name: Lint with PSScriptAnalyzer
     runs-on: windows-latest
     defaults:
       run:

--- a/RestSetAcls/RestSetAcls/SddlUtils.ps1
+++ b/RestSetAcls/RestSetAcls/SddlUtils.ps1
@@ -39,8 +39,8 @@ function Get-AllAceFlagsMatch {
     )
 
     foreach ($ace in $SecurityDescriptor.DiscretionaryAcl) {
-        $hasAllBitsFromEnabledFlags = ($ace.AceFlags -band $EnabledFlags) -eq $EnabledFlags
-        $hasNoBitsFromDisabledFlags = ($ace.AceFlags -band $DisabledFlags) -eq 0
+        $hasAllBitsFromEnabledFlags = ([int]$ace.AceFlags -band [int]$EnabledFlags) -eq [int]$EnabledFlags
+        $hasNoBitsFromDisabledFlags = ([int]$ace.AceFlags -band [int]$DisabledFlags) -eq 0
         if (-not ($hasAllBitsFromEnabledFlags -and $hasNoBitsFromDisabledFlags)) {
             return $false
         }
@@ -61,13 +61,13 @@ function Set-AceFlags {
         [System.Security.AccessControl.AceFlags]$DisableFlags
     )
 
-    if ($EnableFlags -band $DisableFlags) {
+    if ([int]$EnableFlags -band [int]$DisableFlags) {
         throw "Enable and disable flags cannot overlap"
     }
 
     # Create new ACEs with updated flags
     $newAces = $SecurityDescriptor.DiscretionaryAcl | ForEach-Object {
-        $aceFlags = ($_.AceFlags -bor $EnableFlags) -band (-bnot $DisableFlags)
+        $aceFlags = ([int]$_.AceFlags -bor [int]$EnableFlags) -band (-bnot [int]$DisableFlags)
 
         if ($_.GetType().Name -eq "CommonAce") {
             [System.Security.AccessControl.CommonAce]::new(

--- a/RestSetAcls/build.depend.psd1
+++ b/RestSetAcls/build.depend.psd1
@@ -9,5 +9,5 @@
 
     Pester           = 'latest'
     PSScriptAnalyzer = 'latest'
-    'Az.Storage'     = '6.0.0'
+    'Az.Storage'     = '8.1.0'
 }

--- a/RestSetAcls/publish-tools.psm1
+++ b/RestSetAcls/publish-tools.psm1
@@ -49,7 +49,7 @@ function Publish-Local {
     Write-Host "Done" -ForegroundColor Gray
 
     Write-Host "`nInstalling $moduleName from $repoName" -ForegroundColor White
-    Install-Module -Name $moduleName -Repository $repoName -Force
+    Install-Module -Name $moduleName -Repository $repoName -AllowClobber -Force
     Write-Host "Done" -ForegroundColor Gray
 }
 


### PR DESCRIPTION
The cast from `AceFlags` to `int` can be done implicitly on PowerShell 7, but not 5. This makes the cast explicit, so that it also works in PowerShell 5, and adds testing on PowerShell 5 to catch such errors next time