### PR TITLE
Fix CheckAADConnectivity for Server Core + PowerShell 5

### DIFF
--- a/AzFilesHybrid/AzFilesHybrid/AzFilesHybrid.psm1
+++ b/AzFilesHybrid/AzFilesHybrid/AzFilesHybrid.psm1
@@ -3686,7 +3686,7 @@ function Debug-AzStorageAccountEntraKerbAuth {
                 $checksExecuted += 1;
                 $Context = Get-AzContext
                 $TenantId = $Context.Tenant
-                $Response = Invoke-WebRequest -Method POST https://login.microsoftonline.com/$TenantId/kerberos
+                $Response = Invoke-WebRequest -Method POST -Uri https://login.microsoftonline.com/$TenantId/kerberos -UseBasicParsing
                 if ($Response.StatusCode -eq 200)
                 {
                     $checks["CheckAADConnectivity"].Result = "Passed"


### PR DESCRIPTION
The `-UseBasicParsing` switch is required on PowerShell 5 for Server Core; it has no effect on PowerShell 7. 


See [PowerShell 5 documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-5.1#parameters):

> ## `-UseBasicParsing`
> Indicates that the cmdlet uses the response object for HTML content without Document Object Model (DOM) parsing. This parameter is required when Internet Explorer is not installed on the computers, such as on a Server Core installation of a Windows Server operating system.

See [PowerShell 7 documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.4#parameters):

> ## `-UseBasicParsing`
> This parameter has been deprecated. Beginning with PowerShell 6.0.0, all Web requests use basic parsing only. This parameter is included for backwards compatibility only and any use of it has no effect on the operation of the cmdlet.