### PR TITLE
Replace RestSetAcls SkipWarning switch with Confirm

### DIFF
--- a/RestSetAcls/RestSetAcls/Convert.ps1
+++ b/RestSetAcls/RestSetAcls/Convert.ps1
@@ -243,7 +243,9 @@ function Convert-SecurityDescriptor {
         # Convert a security descriptor from SDDL to Base64
         Convert-SecurityDescriptor "O:BAG:BAD:(A;;FA;;;SY)" -From Sddl -To Base64
 #>
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = 'Low')]
     [OutputType([System.Security.AccessControl.RawSecurityDescriptor], [string], [byte[]])]
     param (
         [Parameter(Mandatory = $true, Position = 0, ValueFromPipeline = $true)]

--- a/RestSetAcls/RestSetAcls/PrintUtils.ps1
+++ b/RestSetAcls/RestSetAcls/PrintUtils.ps1
@@ -1,17 +1,3 @@
-function Ask([Parameter(Mandatory = $false)][string] $question) {
-    while ($true) {
-        $yn = Read-Host "${question} [Y/n]"
-        $yn = $yn.Trim().ToLower()
-        if ($yn -eq 'n') {
-            return $false
-        }
-        elseif ($yn -eq '' -or $yn -eq 'y') {
-            return $true
-        }
-        Write-Host "Invalid answer '$yn'. Answer with either 'y' or 'n'" -ForegroundColor Red
-    }
-}
-
 function Get-IsPowerShellIse {
     return $host.Name -eq "Windows PowerShell ISE Host"
 }
@@ -88,3 +74,24 @@ function Write-Failure {
     }
 }
 
+function Write-SddlWarning {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Current,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Recommended
+    )
+    Write-WarningHeader
+    Write-Host "The SDDL string has non-standard inheritance rules." -ForegroundColor White
+    Write-Host "It is recommended to set OI (Object Inherit) and CI (Container Inherit) on every permission. " -ForegroundColor Gray
+    Write-Host "This ensures that the permissions are inherited by files and folders created in the future." -ForegroundColor Gray
+    Write-Host "To learn more, see " -ForegroundColor Gray -NoNewline
+    Write-Host "https://aka.ms/restsetacls/faq" -ForegroundColor DarkCyan
+    Write-Host
+    Write-Host "   Current:     "  -NoNewline -ForegroundColor Yellow
+    Write-Host $Current
+    Write-Host "   Recommended: " -NoNewline -ForegroundColor Green
+    Write-Host $Recommended
+
+}

--- a/RestSetAcls/test/integration/RestSetAcls.Tests.ps1
+++ b/RestSetAcls/test/integration/RestSetAcls.Tests.ps1
@@ -594,7 +594,7 @@ Describe "Set-AzFileAclRecursive" {
 
         # Set O:SYG:SYD:(A;OICIIO;0x1200a9;;;AU) recursively on the parent folder
         $sddl = "O:SYG:SYD:(A;OICIIO;0x1200a9;;;AU)"
-        Set-AzFileAclRecursive -Context $global:context -FileShareName $global:fileShareName -FilePath $folder -SddlPermission $sddl -SkipWarning
+        Set-AzFileAclRecursive -Context $global:context -FileShareName $global:fileShareName -FilePath $folder -SddlPermission $sddl -Confirm:$false
 
         # Check that the SDDL matches the documented state:
         #
@@ -641,7 +641,7 @@ Describe "Set-AzFileAclRecursive" {
 
         # Set O:SYG:SYD:(A;OICINP;0x1200a9;;;AU) recursively on folder
         $sddl = "O:SYG:SYD:(A;OICINP;0x1200a9;;;AU)"
-        Set-AzFileAclRecursive -Context $global:context -FileShareName $global:fileShareName -FilePath $folder -SddlPermission $sddl -SkipWarning
+        Set-AzFileAclRecursive -Context $global:context -FileShareName $global:fileShareName -FilePath $folder -SddlPermission $sddl -Confirm:$false
 
         # Check that the SDDL matches the documented state:
         #


### PR DESCRIPTION
`-Confirm:$false` is the standard way to opt out of confirmation prompts