### PR TITLE
Add -Reset switch to Restore-AzFileAclInheritance

### DIFF
--- a/RestSetAcls/RestSetAcls/RestSetAcls.psd1
+++ b/RestSetAcls/RestSetAcls/RestSetAcls.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'RestSetAcls.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.2.3'
+    ModuleVersion     = '0.2.4'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/RestSetAcls/RestSetAcls/RestSetAcls.psm1
+++ b/RestSetAcls/RestSetAcls/RestSetAcls.psm1
@@ -1145,6 +1145,11 @@ function Restore-AzFileAclInheritance {
     .PARAMETER Path
     Specifies the root directory path for recursive inheritance restoration. Used in recursive mode.
 
+    .PARAMETER Reset
+    If specified, resets the ACL of the child file(s) or directory(ies) before restoring inheritance. Used in both
+    single and recursive modes. This option is useful when you want child items to only have permissions obtained
+    through inheritance, and want to discard any permissions that they currently hold.
+
     .OUTPUTS
     System.Security.AccessControl.GenericSecurityDescriptor
     In single mode, returns the updated ACL for the child file or directory.
@@ -1182,7 +1187,8 @@ function Restore-AzFileAclInheritance {
         [Parameter(Mandatory = $true, ParameterSetName = "Recursive")]
         [string]$Path,
 
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false, ParameterSetName = "Single")]
+        [Parameter(Mandatory = $false, ParameterSetName = "Recursive")]
         [switch]$Reset = $false
     )
 

--- a/RestSetAcls/RestSetAcls/RestSetAcls.psm1
+++ b/RestSetAcls/RestSetAcls/RestSetAcls.psm1
@@ -1180,7 +1180,10 @@ function Restore-AzFileAclInheritance {
         [switch]$Recursive,
 
         [Parameter(Mandatory = $true, ParameterSetName = "Recursive")]
-        [string]$Path
+        [string]$Path,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Reset = $false
     )
 
     if ($PSCmdlet.ParameterSetName -eq "Recursive") {
@@ -1206,6 +1209,7 @@ function Restore-AzFileAclInheritance {
             -FileShareName $FileShareName `
             -ParentAcl $parentAcl `
             -ChildPath $ChildPath `
+            -Reset:$Reset `
             -WhatIf:$WhatIfPreference
     }
     elseif ($PSCmdlet.ParameterSetName -eq "Recursive" -and $Recursive) {  
@@ -1215,6 +1219,7 @@ function Restore-AzFileAclInheritance {
 
         Restore-AzFileAclInheritanceRecursive `
             -DirectoryClient $parentFile.ShareDirectoryClient `
+            -Reset:$Reset `
             -PassThru `
             -WhatIf:$WhatIfPreference `
         | ForEach-Object {
@@ -1250,7 +1255,10 @@ function Restore-AzFileAclInheritanceSingle {
         [System.Security.AccessControl.GenericSecurityDescriptor]$ParentAcl,
 
         [Parameter(Mandatory = $true)]
-        [string]$ChildPath
+        [string]$ChildPath,
+
+        [Parameter(Mandatory = $true)]
+        [switch]$Reset
     )
 
     # Presupposition: the parent path exists and is a directory. It is the responsibility of the caller to check this.
@@ -1264,23 +1272,36 @@ function Restore-AzFileAclInheritanceSingle {
     # Get parent and child ACLs
     $childAcl = Get-AzFileAcl -File $childFile -OutputFormat Raw
     $childIsFolder = $childFile -is [Microsoft.WindowsAzure.Commands.Common.Storage.ResourceModel.AzureStorageFileDirectory]
-
-    # Compute inheritance
-    $newChildAcl = CreatePrivateObjectSecurityEx `
-        -ParentDescriptor $ParentAcl `
-        -CreatorDescriptor $childAcl `
-        -IsDirectory $childIsFolder
-
     $childAclFormat = if ($childIsFolder) { [SecurityDescriptorFormat]::FolderAcl } else { [SecurityDescriptorFormat]::FileAcl }
 
     # Optionally log SDDL for debugging
     if ($VerbosePreference -ne 'SilentlyContinue') {
         $parentSddl = Convert-SecurityDescriptor $parentAcl -To Sddl
-        Write-Verbose "Parent SDDL: $parentSddl"
+        Write-Verbose "Parent folder SDDL: $parentSddl"
         $childSddl = Convert-SecurityDescriptor $newChildAcl -To Sddl
-        Write-Verbose "Child SDDL: $childSddl"
+        Write-Verbose "Child item SDDL: $childSddl"
+    }
+
+    # If reset is passed, we should reset DACL and SACL. We keep the owner and group.
+    if ($Reset) {
+        Reset-SecurityDescriptor -SecurityDescriptor $childAcl
+        if ($VerbosePreference -ne 'SilentlyContinue') {
+            $childNewSddl = Convert-SecurityDescriptor $childAcl -To Sddl
+            Write-Verbose "Running in reset mode. Will compute inheritance on reset child SDDL: $childNewSddl"
+        }
+    }
+
+    # Compute inheritance
+    $newChildAcl = CreatePrivateObjectSecurityEx `
+        -ParentDescriptor $ParentAcl `
+        -CreatorDescriptor $childAcl `
+        -IsDirectory $childIsFolder `
+        -Verbose:$VerbosePreference
+
+    # Optionally log SDDL for debugging
+    if ($VerbosePreference -ne 'SilentlyContinue') {
         $childNewSddl = Convert-SecurityDescriptor $childAcl -To Sddl
-        Write-Verbose "New child SDDL: $childNewSddl"
+        Write-Verbose "Computed inheritance, child should get SDDL: $childNewSddl"
     }
 
     # Update ACL according to inheritance
@@ -1297,6 +1318,9 @@ function Restore-AzFileAclInheritanceRecursive {
     param (
         [Parameter(Mandatory = $true)]
         [Azure.Storage.Files.Shares.ShareDirectoryClient]$DirectoryClient,
+
+        [Parameter(Mandatory = $true)]
+        [switch]$Reset,
 
         [Parameter(Mandatory = $false)]
         [switch]$PassThru = $false
@@ -1337,15 +1361,21 @@ function Restore-AzFileAclInheritanceRecursive {
 
         # Iterate over the contents of the directory
         foreach ($item in $directoryClient.GetFilesAndDirectories($options).GetEnumerator()) {
-            $itemPermissionFormat = if ($item.IsDirectory) { "FolderAcl" } else { "FileAcl" }
-
             # Get ACL for the item
             $itemPermission = Get-AzFileAclFromKey `
                 -Key $item.PermissionKey `
                 -ShareClient $shareClient `
-                -OutputFormat $itemPermissionFormat
+                -OutputFormat Raw
+
+            if ($Reset) {
+                # Reset the DACL and SACL, keeping owner and group
+                Reset-SecurityDescriptor -SecurityDescriptor $itemPermission
+            }
 
             # Compute inheritance
+            $itemPermissionFormat = if ($item.IsDirectory) { [SecurityDescriptorFormat]::FolderAcl } else { [SecurityDescriptorFormat]::FileAcl }
+            $itemPermission = Convert-SecurityDescriptor $itemPermission -From Raw -To $itemPermissionFormat
+
             $itemNewPermission = CreatePrivateObjectSecurityEx `
                 -ParentDescriptor $directoryPermission `
                 -CreatorDescriptor $itemPermission `

--- a/RestSetAcls/RestSetAcls/SddlUtils.ps1
+++ b/RestSetAcls/RestSetAcls/SddlUtils.ps1
@@ -79,6 +79,51 @@ function Set-AceFlags {
 
 <#
 .SYNOPSIS
+This enum defines the ACL revision levels that are used in Windows security descriptors.
+.LINK
+https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/20233ed8-a6c6-4097-aafa-dd545ed24428
+#>
+enum AclRevision {
+    # When set to 0x02, only AceTypes 0x00, 0x01, 0x02, 0x03, 0x11, 0x12, and 0x13 can be present in the ACL.
+    # An AceType of 0x11 is used for SACLs but not for DACLs. For more information about ACE types, see MS-DTYP section
+    # 2.4.4.1.
+    ACL_REVISION = 0x00000002
+
+    # When set to 0x04, AceTypes 0x05, 0x06, 0x07, 0x08, and 0x11 are allowed. ACLs of revision 0x04 are applicable 
+    # only to directory service objects. An AceType of 0x11 is used for SACLs but not for DACLs.
+    ACL_REVISION_DS = 0x00000004
+}
+
+function Get-EmptyRawAcl {
+    $revision = [AclRevision]::ACL_REVISION
+    $capacity = 0
+    return [System.Security.AccessControl.RawAcl]::new([int]$revision, $capacity)
+}
+
+function Reset-SecurityDescriptor {
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [System.Security.AccessControl.RawSecurityDescriptor]$SecurityDescriptor
+    )
+
+    process {
+        $flagsToRemove = [System.Security.AccessControl.ControlFlags]::DiscretionaryAclAutoInherited -bor `
+                         [System.Security.AccessControl.ControlFlags]::DiscretionaryAclProtected -bor `
+                         [System.Security.AccessControl.ControlFlags]::SystemAclAutoInherited -bor `
+                         [System.Security.AccessControl.ControlFlags]::SystemAclProtected -bor `
+                         [System.Security.AccessControl.ControlFlags]::DiscretionaryAclPresent -bor `
+                         [System.Security.AccessControl.ControlFlags]::SystemAclPresent
+        
+        $controlFlags = [int]$SecurityDescriptor.ControlFlags -band (-bnot [int]$flagsToRemove)
+
+        $SecurityDescriptor.DiscretionaryAcl = Get-EmptyRawAcl
+        $SecurityDescriptor.SystemAcl = Get-EmptyRawAcl
+        $SecurityDescriptor.SetFlags($controlFlags)
+    }
+}
+
+<#
+.SYNOPSIS
 Object-specific rights for files and folders.
 #>
 enum SpecificRights {

--- a/RestSetAcls/RestSetAcls/SddlUtils.ps1
+++ b/RestSetAcls/RestSetAcls/SddlUtils.ps1
@@ -101,6 +101,9 @@ function Get-EmptyRawAcl {
 }
 
 function Reset-SecurityDescriptor {
+    [CmdletBinding(
+        SupportsShouldProcess = $true,
+        ConfirmImpact = 'Low')]
     param (
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [System.Security.AccessControl.RawSecurityDescriptor]$SecurityDescriptor
@@ -116,9 +119,11 @@ function Reset-SecurityDescriptor {
         
         $controlFlags = [int]$SecurityDescriptor.ControlFlags -band (-bnot [int]$flagsToRemove)
 
-        $SecurityDescriptor.DiscretionaryAcl = Get-EmptyRawAcl
-        $SecurityDescriptor.SystemAcl = Get-EmptyRawAcl
-        $SecurityDescriptor.SetFlags($controlFlags)
+        if ($PSCmdlet.ShouldProcess("SecurityDescriptor", "Reset ControlFlags, DACL and SACL")) {
+            $SecurityDescriptor.DiscretionaryAcl = Get-EmptyRawAcl
+            $SecurityDescriptor.SystemAcl = Get-EmptyRawAcl
+            $SecurityDescriptor.SetFlags($controlFlags)
+        }
     }
 }
 

--- a/RestSetAcls/docs/Restore-AzFileAclInheritance.md
+++ b/RestSetAcls/docs/Restore-AzFileAclInheritance.md
@@ -154,7 +154,7 @@ Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: False
 Accept pipeline input: False

--- a/RestSetAcls/docs/Restore-AzFileAclInheritance.md
+++ b/RestSetAcls/docs/Restore-AzFileAclInheritance.md
@@ -15,13 +15,13 @@ Applies ACL inheritance from parent folders to child files or folders.
 ### Recursive
 ```
 Restore-AzFileAclInheritance -Context <IStorageContext> -FileShareName <String> [-Recursive] -Path <String>
- [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Reset] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Single
 ```
 Restore-AzFileAclInheritance -Context <IStorageContext> -FileShareName <String> -ParentPath <String>
- -ChildPath <String> [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ -ChildPath <String> [-Reset] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -142,6 +142,25 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Reset
+If specified, resets the ACL of the child file(s) or directory(ies) before restoring inheritance.
+Used in both
+single and recursive modes.
+This option is useful when you want child items to only have permissions obtained
+through inheritance, and want to discard any permissions that they currently hold.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -WhatIf
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
@@ -195,8 +214,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### System.Object
-### Returns information about processed files and directories, including success or failure for each item.
+### System.Security.AccessControl.GenericSecurityDescriptor
+### In single mode, returns the updated ACL for the child file or directory.
 ## NOTES
 
 ## RELATED LINKS


### PR DESCRIPTION
Add an option to reset all child folders, such that they only contain permissions inherited from parent.