### PR TITLE
Fix RestSetAcls parsing bug in PowerShell 5

### DIFF
--- a/.github/workflows/RestSetAcls.yml
+++ b/.github/workflows/RestSetAcls.yml
@@ -73,13 +73,27 @@ jobs:
           .\init.ps1
           Test-Manifest
 
-  lint-with-PSScriptAnalyzer:
-    name: Lint with PSScriptAnalyzer
+  lint:
+    name: Lint in PowerShell 7
     runs-on: windows-latest
     defaults:
       run:
         working-directory: .\RestSetAcls
         shell: pwsh
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint with PSScriptAnalyzer
+        run: |
+          .\init.ps1
+          Lint
+  
+  lint-powershell-5:
+    name: Lint in PowerShell 5.1
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: .\RestSetAcls
+        shell: powershell
     steps:
       - uses: actions/checkout@v4
       - name: Lint with PSScriptAnalyzer

--- a/RestSetAcls/RestSetAcls/RestSetAcls.psm1
+++ b/RestSetAcls/RestSetAcls/RestSetAcls.psm1
@@ -1234,7 +1234,7 @@ function Restore-AzFileAclInheritance {
             }
             $processedCount++
             Write-Output $_
-        }
+        } `
         | Write-LiveFilesAndFoldersProcessingStatus -RefreshRateHertz 10 -StartTime $startTime `
         | ForEach-Object { if ($PassThru) { Write-Output $_ } }
 


### PR DESCRIPTION
Missing backtick caused parsing error in PowerShell 5 only. PowerShell 7 works fine. No alarm bells went off because we only lint in PowerShell 7, where things were fine.

This PR fixes that error, and adds linting in PowerShell 5 to catch this in the future.