### PR TITLE
Add improvements to PowerShell 5 support

### DIFF
--- a/RestSetAcls/RestSetAcls/Convert.ps1
+++ b/RestSetAcls/RestSetAcls/Convert.ps1
@@ -39,7 +39,10 @@ function Get-InferredAclFormat {
             }
         }
         
-        throw "Could not infer the format of the input. Expected SDDL string, Base64 string, byte array, RawSecurityDescriptor or CommonSecurityDescriptor."
+        throw (
+            "Could not infer the format of the input. Got a value of type $($Acl.GetType().FullName). " + 
+            "Expected SDDL string, Base64 string, byte array, RawSecurityDescriptor or CommonSecurityDescriptor."
+        )
     }
 }
 

--- a/RestSetAcls/RestSetAcls/RestSetAcls.psd1
+++ b/RestSetAcls/RestSetAcls/RestSetAcls.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'RestSetAcls.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.2.4'
+    ModuleVersion     = '0.2.5'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/RestSetAcls/RestSetAcls/RestSetAcls.psm1
+++ b/RestSetAcls/RestSetAcls/RestSetAcls.psm1
@@ -1414,7 +1414,7 @@ function Restore-AzFileAclInheritanceRecursive {
                 Write-Output @{
                     Path = $itemClient.Path
                     IsDirectory = $item.IsDirectory
-                    NewPermission = (Convert-SecurityDescriptor $itemNewPermission -To Sddl)
+                    NewPermission = (Convert-SecurityDescriptor $itemNewPermission -From $itemPermissionFormat -To Sddl)
                     PermissionKey = $newPermissionKey
                     Success = $true
                 }


### PR DESCRIPTION
Fix integration tests for PowerShell 5 (mostly), and improve error messages in ACL conversion, to make it easier to debug issues.