### PR TITLE
Do not overwrite the output file on subsequent stop commands

### DIFF
--- a/NfsDiagnostics/README
+++ b/NfsDiagnostics/README
@@ -19,12 +19,16 @@ If issue can be easily reproduced:
    In case the service is Azure NFSv3 blob service, replace v4 above with v3b.
 5) Repro the issue.
 6) Run "./nfsclientlogs.sh stop"
-7) Above command generates output.zip
-8) Send the output.zip file to Microsoft support against your support case.
+7) Above command generates output_TIMESTAMP.zip
+8) Send the output_TIMESTAMP.zip file to Microsoft support against your support case.
+
+Important Note:
+1) Please make sure to run the "start" and "stop" commands from the same CWD (current working directory).
+2) Every time "stop" is run a new log bundle will be created, irrespective of whether a matching "start" was performed or not. Please make sure that you provide us the correct log bundle.
 
 Contents of Zip file:
 1) nfs_dmesg - System logs since the last reboot.
-2) cifs_trace - Output of trace-cmd, which contain the kernel event logs.
+2) nfs_trace - Output of trace-cmd, which contain the kernel event logs.
 3) os_details.txt - Info about the operating system, which will help developers to understand which features/fixes are missing. 
 4) nfs_traffic.pcap - network capture of NFS traffic in case CaptureNetwork option was used.
 

--- a/NfsDiagnostics/nfsclientlogs.sh
+++ b/NfsDiagnostics/nfsclientlogs.sh
@@ -2,6 +2,7 @@
 
 # Simplified NFS diagnostics: capture tcpdump directly into output directory
 PIDFILE="/run/nfsclientlog.pid"
+STATEFILE="/run/nfsclientlog.state"
 RPCDEBUG_STATEFILE="/run/nfsclientlog.rpcdebug"
 DIRNAME="./output"
 NFS_PORT=2049
@@ -46,6 +47,10 @@ main() {
 }
 
 start() {
+  if [[ -f "${STATEFILE}" ]]; then
+    echo "Error: a previous 'start' session is already in progress. Run 'stop' first."
+    exit 1
+  fi
   if [ -f "${PIDFILE}" ]; then
     read -r _running_pid < "${PIDFILE}" 2>/dev/null
     if [ -n "$_running_pid" ] && ps -p "$_running_pid" -o comm= 2>/dev/null | grep -q '^tcpdump$'; then
@@ -55,6 +60,7 @@ start() {
     # Stale PID file — process gone or not tcpdump
     rm -f "${PIDFILE}"
   fi
+  touch "${STATEFILE}"
   init
   start_trace "$@"
   dump_os_information
@@ -203,6 +209,10 @@ trace_nfsbpf() {
 }
 
 stop() {
+  if [[ ! -f "${STATEFILE}" ]]; then
+    echo "Warning: 'stop' called without a matching 'start'. The log bundle may be incomplete."
+  fi
+  mkdir -p "${DIRNAME}"
   dmesg -T > "${DIRNAME}/nfs_dmesg"
   stop_trace
   stop_capture_network
@@ -213,7 +223,14 @@ stop() {
   mv nfs_diag.txt "${DIRNAME}"
   mv os_details.txt "${DIRNAME}"
   mv process_callstack.txt "${DIRNAME}"
-  zip -r "$(basename ${DIRNAME}).zip" "${DIRNAME}"
+
+  timestamp=$(date +"%Y%m%d_%H%M%S_%N")
+  archive_name="$(basename "${DIRNAME}")_${timestamp}.zip"
+  zip -r "${archive_name}" "${DIRNAME}"
+
+  echo "Logs collected in ${DIRNAME} and archived as ${archive_name}"
+
+  rm -f "${STATEFILE}"
   return 0
 }
 

--- a/SMBDiagnostics/README
+++ b/SMBDiagnostics/README
@@ -17,8 +17,12 @@ If issue can be easily reproduced:
    "./smbclientlogs.sh start CaptureNetwork" (in case Microsoft instructs you to use this option)
 5) Repro the issue.
 6) Run "./smbclientlogs.sh stop"
-7) Above command generates output.zip
-8) Send the output.zip file to Microsoft support against your support case.
+7) Above command generates output_TIMESTAMP.zip
+8) Send the output_TIMESTAMP.zip file to Microsoft support against your support case.
+
+Important Note:
+1) Please make sure to run the "start" and "stop" commands from the same CWD (current working directory).
+2) Every time "stop" is run a new log bundle will be created, irrespective of whether a matching "start" was performed or not. Please make sure that you provide us the correct log bundle.
 
 Contents of Zip file:
 1) cifs_diag.txt - Internal debug data and stats from the SMB client.

--- a/SMBDiagnostics/smbclientlogs.sh
+++ b/SMBDiagnostics/smbclientlogs.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PIDFILE="/tmp/smbclientlog.pid"
+STATEFILE="/tmp/smbclientlog.state"
 DIRNAME="./output"
 CIFS_PORT=445
 TRACE_CIFSBPF_ABS_PATH="$(cd "$(dirname "trace-cifsbpf")" && pwd)/$(basename "trace-cifsbpf")"
@@ -196,6 +197,10 @@ trace_cifsbpf() {
 }
 
 start() {
+  if [[ -f "${STATEFILE}" ]]; then
+    echo "Warning: a previous 'start' session is already in progress. Run 'stop' first."
+    exit 1
+  fi
   init
   start_trace $@
   dump_os_information
@@ -216,9 +221,14 @@ start() {
   if [[ "$*" =~ "OnAnomaly" ]]; then
     trace_cifsbpf
   fi
+
+  touch "${STATEFILE}"
 }
 
 stop() {
+  if [[ ! -f "${STATEFILE}" ]]; then
+    echo "Warning: 'stop' called without a matching 'start'. The log bundle may be incomplete."
+  fi
   dmesg -T > "${DIRNAME}/cifs_dmesg"
   stop_trace
   stop_capture_network
@@ -234,12 +244,19 @@ stop() {
   echo -e "======= Dumping AzFileAuth diagnostics  ========" > azfileauth.txt
   dump_azfileauth_logs "azfileauth.txt"
 
+  timestamp=$(date +"%Y%m%d_%H%M%S")
+
   mv system_logs.txt "${DIRNAME}"
   mv azfileauth.txt "${DIRNAME}"
   mv cifs_diag.txt "${DIRNAME}"
   mv os_details.txt "${DIRNAME}"
   mv process_callstack.txt "${DIRNAME}"
-  zip -r "$(basename ${DIRNAME}).zip" "${DIRNAME}"
+  zip -r "$(basename ${DIRNAME})_${timestamp}.zip" "${DIRNAME}"
+
+  echo "Logs collected in ${DIRNAME} and archived as $(basename ${DIRNAME})_${timestamp}.zip"
+
+  rm -f "${STATEFILE}"
+
   return 0;
 }
 

--- a/SMBDiagnostics/smbclientlogs.sh
+++ b/SMBDiagnostics/smbclientlogs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-PIDFILE="/tmp/smbclientlog.pid"
-STATEFILE="/tmp/smbclientlog.state"
+PIDFILE="/run/smbclientlog.pid"
+STATEFILE="/run/smbclientlog.state"
 DIRNAME="./output"
 CIFS_PORT=445
 TRACE_CIFSBPF_ABS_PATH="$(cd "$(dirname "trace-cifsbpf")" && pwd)/$(basename "trace-cifsbpf")"
@@ -198,9 +198,10 @@ trace_cifsbpf() {
 
 start() {
   if [[ -f "${STATEFILE}" ]]; then
-    echo "Warning: a previous 'start' session is already in progress. Run 'stop' first."
+    echo "Error: a previous 'start' session is already in progress. Run 'stop' first."
     exit 1
   fi
+  touch "${STATEFILE}"
   init
   start_trace $@
   dump_os_information
@@ -221,14 +222,13 @@ start() {
   if [[ "$*" =~ "OnAnomaly" ]]; then
     trace_cifsbpf
   fi
-
-  touch "${STATEFILE}"
 }
 
 stop() {
   if [[ ! -f "${STATEFILE}" ]]; then
     echo "Warning: 'stop' called without a matching 'start'. The log bundle may be incomplete."
   fi
+  mkdir -p "${DIRNAME}"
   dmesg -T > "${DIRNAME}/cifs_dmesg"
   stop_trace
   stop_capture_network
@@ -244,16 +244,17 @@ stop() {
   echo -e "======= Dumping AzFileAuth diagnostics  ========" > azfileauth.txt
   dump_azfileauth_logs "azfileauth.txt"
 
-  timestamp=$(date +"%Y%m%d_%H%M%S")
+  timestamp=$(date +"%Y%m%d_%H%M%S_%N")
+  archive_name="$(basename "${DIRNAME}")_${timestamp}.zip"
 
   mv system_logs.txt "${DIRNAME}"
   mv azfileauth.txt "${DIRNAME}"
   mv cifs_diag.txt "${DIRNAME}"
   mv os_details.txt "${DIRNAME}"
   mv process_callstack.txt "${DIRNAME}"
-  zip -r "$(basename ${DIRNAME})_${timestamp}.zip" "${DIRNAME}"
+  zip -r "${archive_name}" "${DIRNAME}"
 
-  echo "Logs collected in ${DIRNAME} and archived as $(basename ${DIRNAME})_${timestamp}.zip"
+  echo "Logs collected in ${DIRNAME} and archived as ${archive_name}"
 
   rm -f "${STATEFILE}"
 


### PR DESCRIPTION
- Track the state of the smbdiagnostics and nfsdiagnostics tool in a statefile.
- If the statefile exists and another "start" command is issued, bail out.
- If the statefile does not exist, print a warning but stop log collection anyway.
- Append timestamps to distinguish the different output zips.
- Update the READMEs.